### PR TITLE
Allow multiple watch paths for single target

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -5,16 +5,34 @@ function plugin_read_list() {
   local prefix="BUILDKITE_PLUGIN_MONOREPO_DIFF_$1"
   local suffix="$2"
   local parameter="${prefix}_0_${suffix}"
+  local chained_parameter="${prefix}_0_${suffix}_0"
 
-  if [[ -n "${!parameter:-}" ]]; then
+  # Reads nested list of multiple watch paths
+  if [[ -n "${!parameter:-}" || -n "${!chained_parameter:-}" ]]; then
     local i=0
-    local parameter="${prefix}_${i}_${suffix}"
-    while [[ -n "${!parameter:-}" ]]; do
-      echo "${!parameter}"
+    while [[ -n "${!parameter:-}" || -n "${!chained_parameter:-}" ]]; do
+      local parameter="${prefix}_${i}_${suffix}"
+      # check for single path oldschool
+      if [[ -n "${!parameter:-}" ]]; then
+      	 echo "${!parameter}"
+      else
+        # check for new style
+        local params=()
+        local j=0
+	      while [[ -n "${!chained_parameter:-}" ]]; do
+		      params+=("${!chained_parameter}")
+		      j=$((j+1))
+		      chained_parameter="${prefix}_${i}_${suffix}_${j}"
+	      done
+        echo "${params[@]}"
+      fi
       i=$((i+1))
+      chained_parameter="${prefix}_${i}_${suffix}_0"
       parameter="${prefix}_${i}_${suffix}"
     done
-  elif [[ -n "${!prefix:-}" ]]; then
+  fi
+  # Read one watch with one path
+  if [[ -n "${!prefix:-}" ]]; then
     echo "${!prefix}"
   fi
 }

--- a/lib/watch.bash
+++ b/lib/watch.bash
@@ -4,12 +4,12 @@ set -ueo pipefail
 function has_changed() {
   local diff_output=$1
   local watched_path=$2
-
-  if echo "$diff_output" | grep -q "^$watched_path" ; then
-    return 0
-  else
-    return 1
-  fi
+  for path in $watched_path; do
+    if echo "$diff_output" | grep -q "^$path" ; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 function get_index_of_pipelines_to_trigger() {

--- a/plugin.yml
+++ b/plugin.yml
@@ -11,7 +11,8 @@ configuration:
       type: array
       properties:
         path:
-          type: string
+          type: [string, array]
+          minimum: 1
         config:
           type: object
           properties:

--- a/tests/diff.bats
+++ b/tests/diff.bats
@@ -5,12 +5,8 @@ load '/usr/local/lib/bats/load.bash'
 @test "Run the specified inline diff command" {
   export BUILDKITE_PLUGIN_MONOREPO_DIFF_DIFF="cat $PWD/tests/mocks/diff1"
 
-  stub buildkite-agent \
-    "pipeline upload : echo uploading"
-
   run $PWD/hooks/command
 
-  unstub buildkite-agent
   assert_success
   assert_output --partial "services/foo/serverless.yml"
   assert_output --partial "services/bar/config.yml"
@@ -21,12 +17,8 @@ load '/usr/local/lib/bats/load.bash'
 @test "Run the specified shell script" {
   export BUILDKITE_PLUGIN_MONOREPO_DIFF_DIFF="$PWD/tests/mocks/diff2.sh"
 
-  stub buildkite-agent \
-    "pipeline upload : echo uploading"
-
   run $PWD/hooks/command
 
-  unstub buildkite-agent
   assert_success
   assert_output --partial "diff 2"
 }
@@ -34,12 +26,9 @@ load '/usr/local/lib/bats/load.bash'
 @test "Run default diff command when shell script is not specified" {
   stub git \
     "diff --name-only HEAD~1 : echo services/git/head-minus-1.yml"
-  stub buildkite-agent \
-    "pipeline upload : echo uploading"
 
   run $PWD/hooks/command
 
-  unstub buildkite-agent
   unstub git
   assert_success
   assert_output --partial "services/git/head-minus-1.yml"
@@ -47,9 +36,6 @@ load '/usr/local/lib/bats/load.bash'
 
 @test "Exits on shell script error" {
   export BUILDKITE_PLUGIN_MONOREPO_DIFF_DIFF="$PWD/tests/mocks/thisdoesnotexist.sh"
-
-  stub buildkite-agent \
-    "pipeline upload : echo uploading"
 
   run $PWD/hooks/command
 

--- a/tests/trigger.bats
+++ b/tests/trigger.bats
@@ -44,6 +44,34 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "  - trigger: slug-for-bar"
 }
 
+@test "Generates trigger with multiple paths" {
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_DIFF="cat $PWD/tests/mocks/diff1"
+  # mixed string and array behavior
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_0_PATH="services/foo"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_0_CONFIG_TRIGGER="slug-for-foo"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_1_PATH="services/path-not-in-diff-1"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_1_CONFIG_TRIGGER="slug-for-path-not-in-diff"
+  # path not in diff
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_2_PATH_0="services/path-not-in-diff-2"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_2_CONFIG_TRIGGER="slug-for-path-not-in-diff"
+  # one path in diff, one path not in diff
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_3_PATH_0="services/bar"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_3_PATH_1="services/far"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_3_CONFIG_TRIGGER="slug-for-bar"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_3_CONFIG_LABEL="Bar service deployment"
+  export DEBUG=true
+
+  stub buildkite-agent \
+    "pipeline upload : echo uploading"
+
+  run $PWD/hooks/command
+
+  unstub buildkite-agent
+  assert_success
+  assert_output --partial "  - trigger: slug-for-foo"
+  assert_output --partial "  - trigger: slug-for-bar"
+}
+
 @test "Uses user defined label if it exist" {
   export BUILDKITE_PLUGIN_MONOREPO_DIFF_DIFF="cat $PWD/tests/mocks/diff1"
   export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_0_PATH="services/foo"


### PR DESCRIPTION
Sometimes you'll want to trigger a single pipeline based on multiple
paths not sharing a common root. This change allows you to specify
an array of paths to watch for a single target in addition to preserving
the old behavior of a single string.

I believe this change also unsurfaced a bug with the existing diff tests
where `buildkite-agent pipeline upload` was expected to be called in the
tests but shouldn't acutally be called based on the code in the command
hook.

![](https://media0.giphy.com/media/JIX9t2j0ZTN9S/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>