### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This plugin will assist you in triggering pipelines by watching folders in your 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      chronotc/monorepo-diff#v1.0.0:
-        diff: "git diff --name-only HEAD~1"
-        watch:
-          - path: "foo-service/"
-            config:
-              trigger: "deploy-foo-service"
+      - chronotc/monorepo-diff#v1.0.0:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: "foo-service/"
+              config:
+                trigger: "deploy-foo-service"
 ```
 
 ### Detailed
@@ -24,24 +24,24 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      chronotc/monorepo-diff#v1.0.0:
-        diff: "git diff --name-only $(head -n 1 last_successful_build)"
-        watch:
-          - path: "foo-service/"
-            config:
-              trigger: "deploy-foo-service"
-              build:
-                message: "Deploying foo service"
-                env:
-                  - HELLO=123
-                  - AWS_REGION
-          - path: "ops/terraform/"
-            config:
-              trigger: "provision-terraform-resources"
-              async: true
-        wait: true
-        hooks:
-          - command: "echo $(git rev-parse HEAD) > last_successful_build"
+      - chronotc/monorepo-diff#v1.0.0:
+          diff: "git diff --name-only $(head -n 1 last_successful_build)"
+          watch:
+            - path: "foo-service/"
+              config:
+                trigger: "deploy-foo-service"
+                build:
+                  message: "Deploying foo service"
+                  env:
+                    - HELLO=123
+                    - AWS_REGION
+            - path: "ops/terraform/"
+              config:
+                trigger: "provision-terraform-resources"
+                async: true
+          wait: true
+          hooks:
+            - command: "echo $(git rev-parse HEAD) > last_successful_build"
 ```
 
 ## Configuration
@@ -141,12 +141,12 @@ steps:
     env:
       DEBUG: true
     plugins:
-      chronotc/monorepo-diff:
-        diff: "git diff --name-only HEAD~1"
-        watch:
-          - path: "foo-service/"
-            config:
-              trigger: "deploy-foo-service"
+      - chronotc/monorepo-diff:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: "foo-service/"
+              config:
+                trigger: "deploy-foo-service"
 ```
 
 ## References


### PR DESCRIPTION
Hi @chronotc! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.