### PR TITLE
Fix has_changed with large diff output

### DIFF
--- a/lib/watch.bash
+++ b/lib/watch.bash
@@ -5,7 +5,7 @@ function has_changed() {
   local diff_output=$1
   local watched_path=$2
   for path in $watched_path; do
-    if echo "$diff_output" | grep -q "^$path" ; then
+    if grep -q "^$path" <<< "$diff_output"; then
       return 0
     fi
   done


### PR DESCRIPTION
has_changed uses grep with the quiet flag, which returns after the first match
is found. This causes issues with input that has a large number of lines and a
match that is triggered early, as grep returns and causes the echo to fail
writing to the pipe. Echo's exit status is used for the test because the
pipefail option is set, ultimately causing the change to be skipped.

Fix this by removing the echo, and replacing it with a herestring.