### PR TITLE
Escape dollar sign in build messages

### DIFF
--- a/lib/trigger.bash
+++ b/lib/trigger.bash
@@ -183,6 +183,7 @@ function add_hooks() {
 
 function sanitize_string() {
   local string=$1
-  escaped_quotes="${string//\"/\\\"}"
-  echo "$escaped_quotes"
+  escaped="${string//\"/\\\"}"
+  escaped="${escaped//\$/\$\$}"
+  echo "$escaped"
 }


### PR DESCRIPTION
Currently when commit message includes a dollar sign it's being evaluated by buildkite as a variable. If it includes $0 the build fails.
Escape dollar sign with another dollar sign, as per buildkite documentation: https://buildkite.com/docs/agent/v3/cli-pipeline#environment-variable-substitution