### PR TITLE
Fix queue string when value is *

### DIFF
--- a/lib/trigger.bash
+++ b/lib/trigger.bash
@@ -86,8 +86,8 @@ function add_agents() {
 function add_agents_queue() {
   local queue=$1
 
-  if [[ -n $queue ]]; then
-    pipeline_yml+=("      queue: ${queue}")
+  if [[ -n "$queue" ]]; then
+    pipeline_yml+=("      queue: \"${queue}\"")
   fi
 }
 


### PR DESCRIPTION
when to you want to make a wildcard queue tag, for an example, the * character, you need to force the double quotes on the queue value.