### PR TITLE
Support for environment variables globally in the pipeline

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -19,7 +19,6 @@ populate_pipelines_to_trigger "$diff"
 if [ "${#pipelines_to_trigger[@]}" -eq 0 ]; then
   echo "No changes detected"
 else
-  pipeline_yml+=("steps:")
   generate_pipeline_yml
   output=$(printf '%s\n' "${pipeline_yml[@]}")
 

--- a/lib/trigger.bash
+++ b/lib/trigger.bash
@@ -2,6 +2,10 @@
 set -ueo pipefail
 
 function generate_pipeline_yml() {
+  pipeline_yml+=("env:")
+  add_pipeline_env
+
+  pipeline_yml+=("steps:")
   for pipeline in "${pipelines_to_trigger[@]}";
     do
       set -- $pipeline
@@ -13,6 +17,29 @@ function generate_pipeline_yml() {
     done
   add_wait
   add_hooks
+}
+
+function add_pipeline_env() {
+  local prefix="BUILDKITE_PLUGIN_MONOREPO_DIFF_ENV"
+  local parameter="${prefix}_0"
+
+  if [[ -n "${!parameter:-}" ]]; then
+    local i=0
+    local parameter="${prefix}_${i}"
+    local env
+    while [[ -n "${!parameter:-}" ]]; do
+      while IFS=$'\n' read -r env ; do
+        IFS='=' read -r key value <<< "$env"
+        if [[ -n "$value" ]]; then
+          pipeline_yml+=("  ${key}: ${value}")
+        else
+          pipeline_yml+=("  ${key}: ${!key}")
+        fi
+      done <<< "${!parameter:-}"
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
+  fi
 }
 
 function add_action() {

--- a/plugin.yml
+++ b/plugin.yml
@@ -53,5 +53,7 @@ configuration:
       properties:
         command:
           type: string
+    env:
+      type: array
   required:
     - watch

--- a/tests/trigger.bats
+++ b/tests/trigger.bats
@@ -403,3 +403,29 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "      X: y"
   assert_output --partial "  - command: ./diff 123"
 }
+
+@test "Generates command step with env global in pipeline" {
+  export X="y"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_ENV_0="FOO=bar"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_ENV_1="X"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_DIFF="cat $PWD/tests/mocks/diff1"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_0_PATH="services/foo"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_0_CONFIG_COMMAND="echo 123"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_1_PATH="services/bar"
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_WATCH_1_CONFIG_COMMAND="./diff 123"
+  export DEBUG=true
+
+  stub buildkite-agent \
+    "pipeline upload : echo uploading"
+
+  run $PWD/hooks/command
+
+  unstub buildkite-agent
+  assert_success
+  assert_output --partial "env:"
+  assert_output --partial "  FOO: bar"
+  assert_output --partial "  X: y"
+  assert_output --partial "steps:"
+  assert_output --partial "  - command: echo 123"
+  assert_output --partial "  - command: ./diff 123"
+}


### PR DESCRIPTION
This PR adds the ability to pass global environment variables to the pipeline.

```yaml
env: 
    MESSAGE: hello world
step:
  - commands:
      - "echo $MESSAGE"
...
```