### PR TITLE
feat: use latest binary if plugin version is not specified

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
           run: plugin_test
   - label: ":bomb: Triggering 1"
     plugins:
-      - chronotc/monorepo-diff#v2.0.0:
+      - chronotc/monorepo-diff#v2.0.1:
           diff: "cat ./e2e/one-match-one-miss"
           watch:
             - path: "foo-service/"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
           run: plugin_test
   - label: ":bomb: Triggering 1"
     plugins:
-      - chronotc/monorepo-diff#${BUILDKITE_COMMIT}:
+      - chronotc/monorepo-diff#v2.0.0:
           diff: "cat ./e2e/one-match-one-miss"
           watch:
             - path: "foo-service/"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [created]
 
 jobs:
   publish:
@@ -22,13 +21,14 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
 
-      - name: Build binary
-        run: make build-linux
-
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - name: Build the binary
+        uses: skx/github-action-build@master
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
-          prerelease: true
-          title: "Pre Release"
-          files: monorepo-diff-buildkite-plugin-linux
+          builder: make build-linux RELEASE_VERSION=${{ github.event.release.tag_name }}
+
+      - name: Upload the binary
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: monorepo-diff-buildkite-plugin-linux

--- a/hooks/command
+++ b/hooks/command
@@ -5,8 +5,6 @@ version="${BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_VERSION:-2.0.1}"
 repo="https://github.com/chronotc/monorepo-diff-buildkite-plugin"
 executable="monorepo-diff-buildkite-plugin-linux"
 
-echo "using plugin version: ${version}"
-
 test_mode="${BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_TEST_MODE:-false}"
 
 if [[ "$test_mode" == "false" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -8,6 +8,7 @@ executable="monorepo-diff-buildkite-plugin-linux"
 test_mode="${BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_TEST_MODE:-false}"
 
 if [[ "$test_mode" == "false" ]]; then
+  echo ${repo}/releases/download/v${version}/${executable}
   curl -Lf -o ${executable} ${repo}/releases/download/v${version}/${executable} \
     && chmod +x ${executable}
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -1,16 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-version="${BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_VERSION:-2.0.1}"
+version="${BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_VERSION:-""}"
 repo="https://github.com/chronotc/monorepo-diff-buildkite-plugin"
 executable="monorepo-diff-buildkite-plugin-linux"
-
 test_mode="${BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_TEST_MODE:-false}"
 
+if [ -z ${version} ]; then
+  url=${repo}/releases/latest/download/${executable}
+else
+  url=${repo}/releases/download/v${version}/${executable}
+fi
+
 if [[ "$test_mode" == "false" ]]; then
-  echo ${repo}/releases/download/v${version}/${executable}
-  curl -Lf -o ${executable} ${repo}/releases/download/v${version}/${executable} \
-    && chmod +x ${executable}
+  echo downloading binary from: ${url}
+  curl -Lf -o ${executable} $url && chmod +x ${executable}
 fi
 
 ./${executable}

--- a/main.go
+++ b/main.go
@@ -18,8 +18,11 @@ func setupLogger(logLevel string) {
 	log.SetLevel(ll)
 }
 
+// Version of plugin
+var Version string
+
 func main() {
-	log.Info("--- :one: monorepo-diff")
+	log.Infof("--- :one: monorepo-diff %s", Version)
 
 	plugin, err := initializePlugin(env("BUILDKITE_PLUGINS", ""))
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -2,8 +2,6 @@
 
 load '/usr/local/lib/bats/load.bash'
 
-# https://buildkite.com/kuda/monorepo-diff-buildkite-plugin/builds/110#2b88547e-eb5a-4f99-a83b-affdbcddb303
-
 setup() {
   export BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_TEST_MODE="true"
 


### PR DESCRIPTION
### Added
1. Download the latest version of binary if plugin version is not specified
2. Log plugin binary version