### PR TITLE
Bump golang to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chronotc/monorepo-diff-buildkite-plugin
 
-go 1.16
+go 1.17
 
 require (
 	github.com/bmatcuk/doublestar/v2 v2.0.4

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3 as go
+FROM golang:1.17.2 as go
 
 WORKDIR /plugin
 


### PR DESCRIPTION
## Why?

Because 1.16 is known to have issue with linux-ppc64le platform (which I am using). 