### PR TITLE
prevent incorrect interpolation of env on trigger steps

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,6 +2,6 @@ coverage:
   status:
     project:
       default:
-        target: "79.5%"
+        target: "78%"
     patch:
       enabled: false

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If the version number is not provided then the most recent version of the plugin
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - chronotc/monorepo-diff#v2.1.1:
+      - chronotc/monorepo-diff#v2.1.2:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -36,7 +36,7 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - chronotc/monorepo-diff#v2.1.1:
+      - chronotc/monorepo-diff#v2.1.2:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:
@@ -132,7 +132,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - chronotc/monorepo-diff#v2.1.1:
+      - chronotc/monorepo-diff#v2.1.2:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -208,7 +208,7 @@ hooks:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - chronotc/monorepo-diff#v2.1.1:
+      - chronotc/monorepo-diff#v2.1.2:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: app/cms/

--- a/plugin.go
+++ b/plugin.go
@@ -144,21 +144,22 @@ func appendEnv(watch *WatchConfig, env map[string]string) {
 	watch.Step.Build.Env = parseEnv(watch.Step.Build.RawEnv)
 
 	for key, value := range env {
-		if watch.Step.Env == nil {
-			watch.Step.Env = make(map[string]string)
-		}
+		if watch.Step.Command != "" {
+			if watch.Step.Env == nil {
+				watch.Step.Env = make(map[string]string)
+			}
 
-		watch.Step.Env[key] = value
-
-		if watch.Step.Trigger == "" {
+			watch.Step.Env[key] = value
 			continue
 		}
+		if watch.Step.Trigger != "" {
+			if watch.Step.Build.Env == nil {
+				watch.Step.Build.Env = make(map[string]string)
+			}
 
-		if watch.Step.Build.Env == nil {
-			watch.Step.Build.Env = make(map[string]string)
+			watch.Step.Build.Env[key] = value
+			continue
 		}
-
-		watch.Step.Build.Env[key] = value
 	}
 
 	watch.Step.RawEnv = nil

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -72,7 +72,10 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 				{
 					"path": "watch-path-1",
 					"config": {
-						"command": "echo hello-world"
+						"command": "echo hello-world",
+						"env": [
+							"env4", "hi= bye"
+						]
 					}
 				},
 				{
@@ -96,11 +99,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"agents": {
 							"queue": "queue-1"
 						},
-						"artifacts": [ "artifiact-1" ],
-						"env": [
-							"foo = bar",
-							"env4"
-						]
+						"artifacts": [ "artifiact-1" ]
 					}
 				}
 			]
@@ -128,11 +127,6 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 				Paths: []string{"watch-path-1"},
 				Step: Step{
 					Trigger: "service-2",
-					Env: map[string]string{
-						"env1": "env-1",
-						"env2": "env-2",
-						"env3": "env-3",
-					},
 					Build: Build{
 						Message: "some message",
 						Branch:  "go-rewrite",
@@ -153,6 +147,8 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env1": "env-1",
 						"env2": "env-2",
 						"env3": "env-3",
+						"env4": "env-4",
+						"hi":   "bye",
 					},
 				},
 			},
@@ -176,13 +172,6 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 					Async:     true,
 					Agents:    Agent{Queue: "queue-1"},
 					Artifacts: []string{"artifiact-1"},
-					Env: map[string]string{
-						"foo":  "bar",
-						"env1": "env-1",
-						"env2": "env-2",
-						"env3": "env-3",
-						"env4": "env-4",
-					},
 				},
 			},
 		},


### PR DESCRIPTION
Environment was incorrectly interpolated in 2 places.
This removes the extra env on trigger steps.

Generated Pipeline:
```yaml
steps:
- trigger: app
   build:
     message: 'chore(some-app): pass in correct env'
     branch: renovate/i-am-fake-renovate
     commit: 68d963ed7daee0c84f575eb4aa56c47d3dfd0ad4
     env:
       QUEUE_OVERRIDE: renovate
   env: (this shouldn't be here)
     QUEUE_OVERRIDE: renovate 

```