### PR TITLE
Expand supported attributes for the command step

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ steps:
                   - "logs/*"
                 env:
                   - FOO=bar
+                plugins:
+                  - docker#v3.3.0:
+                      image: node
+                      workdir: /app
             - path: "foo-service/"
               config:
                 trigger: "deploy-foo-service"

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -245,6 +245,29 @@ func TestGeneratePipeline(t *testing.T) {
 			Trigger: "foo-service-pipeline",
 			Build:   Build{Message: "build message"},
 		},
+		{
+			Command:          "echo bye-bye",
+			Concurrency:      5,
+			ConcurrencyGroup: "primary",
+			SoftFail: []ExitStatus{{
+				ExitStatus: 1,
+			}, {
+				ExitStatus: 255,
+			}},
+			Plugins: []map[string]interface{}{{
+				"docker#v3.3.0": map[string]interface{}{
+					"image":   "alpine:latest",
+					"workdir": "/",
+					"environment": []interface{}{
+						"MESSAGE=ciao",
+					},
+					"command": []interface{}{
+						"echo",
+						`"$$MESSAGE"`,
+					},
+				},
+			}},
+		},
 	}
 
 	want :=
@@ -252,6 +275,21 @@ func TestGeneratePipeline(t *testing.T) {
 - trigger: foo-service-pipeline
   build:
     message: build message
+- command: echo bye-bye
+  concurrency: 5
+  concurrency_group: primary
+  plugins:
+  - docker#v3.3.0:
+      command:
+      - echo
+      - '"$$MESSAGE"'
+      environment:
+      - MESSAGE=ciao
+      image: alpine:latest
+      workdir: /
+  soft_fail:
+  - exit_status: 1
+  - exit_status: 255
 - wait
 - command: echo "hello world"
 - command: cat ./file.txt`

--- a/plugin.go
+++ b/plugin.go
@@ -34,17 +34,27 @@ type WatchConfig struct {
 	Step    Step `json:"config"`
 }
 
+type ExitStatus struct {
+	ExitStatus int `json:"exit_status" yaml:"exit_status,omitempty"`
+}
+
 // Step is buildkite pipeline definition
 type Step struct {
-	Trigger   string            `yaml:"trigger,omitempty"`
-	Label     string            `yaml:"label,omitempty"`
-	Build     Build             `yaml:"build,omitempty"`
-	Command   string            `yaml:"command,omitempty"`
-	Agents    Agent             `yaml:"agents,omitempty"`
-	Artifacts []string          `yaml:"artifacts,omitempty"`
-	RawEnv    interface{}       `json:"env" yaml:",omitempty"`
-	Env       map[string]string `yaml:"env,omitempty"`
-	Async     bool              `yaml:"async,omitempty"`
+	Trigger          string                   `yaml:"trigger,omitempty"`
+	Label            string                   `yaml:"label,omitempty"`
+	Build            Build                    `yaml:"build,omitempty"`
+	Command          string                   `yaml:"command,omitempty"`
+	Concurrency      uint                     `yaml:"concurrency,omitempty"`
+	ConcurrencyGroup string                   `json:"concurrency_group" yaml:"concurrency_group,omitempty"`
+	DependsOn        []string                 `json:"depends_on" yaml:"depends_on,omitempty"`
+	Key              string                   `yaml:"key,omitempty"`
+	Agents           Agent                    `yaml:"agents,omitempty"`
+	Artifacts        []string                 `yaml:"artifacts,omitempty"`
+	RawEnv           interface{}              `json:"env" yaml:",omitempty"`
+	Env              map[string]string        `yaml:"env,omitempty"`
+	Async            bool                     `yaml:"async,omitempty"`
+	Plugins          []map[string]interface{} `yaml:"plugins,omitempty"`
+	SoftFail         []ExitStatus             `json:"soft_fail" yaml:"soft_fail,omitempty"`
 }
 
 // Agent is Buildkite agent definition

--- a/plugin.yml
+++ b/plugin.yml
@@ -50,6 +50,12 @@ configuration:
               type: array
             env:
               type: array
+            plugins:
+              type: array
+              items:
+                type: object
+                additionalProperties:
+                  type: object
     wait:
       type: boolean
     hooks:

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -72,9 +72,43 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 				{
 					"path": "watch-path-1",
 					"config": {
+						"label": "hello",
 						"command": "echo hello-world",
 						"env": [
 							"env4", "hi= bye"
+						]
+					}
+				},
+				{
+					"path": "watch-path-1",
+					"config": {
+						"command": "echo bye-bye",
+						"concurrency": 5,
+						"concurrency_group": "primary",
+						"depends_on": [
+							"hello"
+						],
+						"soft_fail": [
+							{
+								"exit_status": 1
+							},
+							{
+								"exit_status": 255
+							}
+						],
+						"plugins": [
+							{
+								"docker#v3.3.0": {
+									"image": "alpine:latest",
+									"workdir": "/",
+									"environment": [
+										"MESSAGE=ciao"
+									],
+									"command": [
+										"echo", "\"$$MESSAGE\""
+									]
+								}
+							}
 						]
 					}
 				},
@@ -142,6 +176,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 			{
 				Paths: []string{"watch-path-1"},
 				Step: Step{
+					Label:   "hello",
 					Command: "echo hello-world",
 					Env: map[string]string{
 						"env1": "env-1",
@@ -150,6 +185,38 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env4": "env-4",
 						"hi":   "bye",
 					},
+				},
+			},
+			{
+				Paths: []string{"watch-path-1"},
+				Step: Step{
+					Command: "echo bye-bye",
+					Env: map[string]string{
+						"env1": "env-1",
+						"env2": "env-2",
+						"env3": "env-3",
+					},
+					Concurrency:      5,
+					ConcurrencyGroup: "primary",
+					DependsOn:        []string{"hello"},
+					SoftFail: []ExitStatus{{
+						ExitStatus: 1,
+					}, {
+						ExitStatus: 255,
+					}},
+					Plugins: []map[string]interface{}{{
+						"docker#v3.3.0": map[string]interface{}{
+							"image":   "alpine:latest",
+							"workdir": "/",
+							"environment": []interface{}{
+								"MESSAGE=ciao",
+							},
+							"command": []interface{}{
+								"echo",
+								`"$$MESSAGE"`,
+							},
+						},
+					}},
 				},
 			},
 			{

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -139,6 +139,46 @@ EOM
           }
         },
         {
+          "path": [
+            "foo-service"
+          ],
+          "config": {
+            "concurrency": 5,
+            "concurrency_group": "abc",
+            "depends_on": [
+              "bar-service-pipeline",
+              "baz-service-pipeline"
+            ],
+            "soft_fail": [
+              {
+                "exit_status": 1,
+              },
+              {
+                "exit_status": 255,
+              }
+            ]
+            "plugins": [
+              {
+                "docker-login#v2.1.0": {
+                  "username": "bob",
+                  "password": "hunter12"
+                }
+              },
+              {
+                "docker#v3.8.0": {
+                  "image": "alpine:latest",
+                  "workdir": "/",
+                  "environment": [
+                    "GREETING=hello",
+                    "FAREWELL=ciao"
+                  ],
+                  "command": ["echo", "\"$MESSAGE\"", "\"$FAREWELL\""]
+                }
+              }
+            ]
+          }
+        },
+        {
           "path": "**/*.md",
           "config": {
             "trigger": "markdown-pipeline"
@@ -177,9 +217,30 @@ steps:
   - tests/*
   async: true
 - command: echo "hello-world"
+- concurrency: 5
+  concurrency_group: abc
+  soft_fail:
+  - exit_status: 1
+  - exit_status: 255
+  depends_on:
+  - bar-service-pipeline
+  - baz-service-pipeline
+  plugins:
+  - docker-login#v2.1.0:
+      password: hunter12
+      username: bob
+  - docker#v3.8.0:
+      command:
+      - echo
+      - '"\$MESSAGE"'
+      - '"\$FAREWELL"'
+      environment:
+      - GREETING=hello
+      - FAREWELL=ciao
+      image: alpine:latest
+      workdir: /
 - wait
 - command: echo "hello world"
 - command: cat ./foo-file.txt
 EOM
 }
-


### PR DESCRIPTION
The current command step type implements a small subset of the
Buildkite command step type. This PR implements the following missing
step fields: 
- currency
- concurrency_group
- depends_on
- plugins

### TODO

- [ ] update e2e tests