### PR TITLE
fix: add logic to determine correct kernel + arch for binary download

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -13,6 +13,11 @@ fi
 plugin=${BUILDKITE_PLUGINS:-""}
 version=$(echo $plugin | sed -e 's/.*monorepo-diff-buildkite-plugin//' -e 's/\".*//')
 kernel=$(uname -s | awk '{print tolower($0)}')
+allowed=("linux darwin")
+if ! [[ "${allowed[*]}" =~ ${kernel} ]]; then
+  exit 1
+fi
+
 repo="https://github.com/chronotc/monorepo-diff-buildkite-plugin"
 executable="monorepo-diff-buildkite-plugin-${kernel}-${arch}"
 test_mode="${BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_TEST_MODE:-false}"

--- a/hooks/command
+++ b/hooks/command
@@ -8,6 +8,9 @@ if [[ "${arm[*]}" =~ ${arch} ]]; then
   arch="arm64"
 elif [[ "${amd[*]}" =~ ${arch} ]]; then
   arch="amd64"
+elif [[ "${arch}" != "ppc64le" ]]; then
+  echo -e "ERROR: unsupported architecture \"${arch}\"" >&2
+  exit 2
 fi
 
 plugin=${BUILDKITE_PLUGINS:-""}
@@ -15,7 +18,8 @@ version=$(echo $plugin | sed -e 's/.*monorepo-diff-buildkite-plugin//' -e 's/\".
 kernel=$(uname -s | awk '{print tolower($0)}')
 allowed=("linux darwin")
 if ! [[ "${allowed[*]}" =~ ${kernel} ]]; then
-  exit 1
+  echo -e "ERROR: unsupported kernel \"${kernel}\"" >&2
+  exit 3
 fi
 
 repo="https://github.com/chronotc/monorepo-diff-buildkite-plugin"

--- a/hooks/command
+++ b/hooks/command
@@ -12,8 +12,9 @@ fi
 
 plugin=${BUILDKITE_PLUGINS:-""}
 version=$(echo $plugin | sed -e 's/.*monorepo-diff-buildkite-plugin//' -e 's/\".*//')
+kernel=$(uname -s | awk '{print tolower($0)}')
 repo="https://github.com/chronotc/monorepo-diff-buildkite-plugin"
-executable="monorepo-diff-buildkite-plugin-linux-${arch}"
+executable="monorepo-diff-buildkite-plugin-${kernel}-${arch}"
 test_mode="${BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_TEST_MODE:-false}"
 
 if [ -z ${version} ]; then

--- a/hooks/command
+++ b/hooks/command
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[ "$(arch)" == "aarch64" ]]; then
+arch="$(arch)"
+arm=("arm armhf aarch64 aarch64_be armv6l armv7l armv8l arm64e") # arm64
+amd=("x86 x86pc i386 i686 i686-64 x64 x86_64 x86_64h athlon")    # amd64
+if [[ "${arm[*]}" =~ ${arch} ]]; then
   arch="arm64"
-else
+elif [[ "${amd[*]}" =~ ${arch} ]]; then
   arch="amd64"
 fi
 


### PR DESCRIPTION
In hopes of fixing #83 .  Added some basic logic to compare the `$(arch)` against a whitelist of known strings for the AMD and ARM architecture families.
(the lists include some 32-bit varieties as `arch` itself allows _selecting_ an architecture, so these 32-bit strings may be indicative of actual 64-bit ISC families).

Disclaimer: I see there is a `ppc64le` binary in the releases.  I had never heard of that flavour of PowerPC until now, so yeah, ~didn't do anything to handle it~ [EDIT: I added a basic string check to whitelist it through 🤷 ].  But if someone (who has one) wants/knows what to check then feel free to amend the PR?