### PR TITLE
Allow all tags when specifying the agent on a step

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -48,9 +48,7 @@ type Step struct {
 }
 
 // Agent is Buildkite agent definition
-type Agent struct {
-	Queue string `yaml:"queue,omitempty"`
-}
+type Agent map[string]string
 
 // Build is buildkite build definition
 type Build struct {

--- a/plugin.yml
+++ b/plugin.yml
@@ -46,6 +46,8 @@ configuration:
               properties:
                 queue:
                   type: string
+              additionalProperties:
+                type: string
             artifacts:
               type: array
             env:

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -97,7 +97,8 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						},
 						"async": true,
 						"agents": {
-							"queue": "queue-1"
+							"queue": "queue-1",
+							"database": "postgres"
 						},
 						"artifacts": [ "artifiact-1" ]
 					}
@@ -170,7 +171,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						},
 					},
 					Async:     true,
-					Agents:    Agent{Queue: "queue-1"},
+					Agents:    map[string]string{"queue": "queue-1", "database": "postgres"},
 					Artifacts: []string{"artifiact-1"},
 				},
 			},


### PR DESCRIPTION
Currently only the `queue` tag can be used when specifying a step's `agents` selector.
This PR allows the user to target agents using any tag.

We hit this problem because we use tags to select agents for a pipeline step.