### PR TITLE
Log pipeline generation and upload errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,5 +32,7 @@ func main() {
 
 	setupLogger(plugin.LogLevel)
 
-	uploadPipeline(plugin, generatePipeline)
+	if _, _, err := uploadPipeline(plugin, generatePipeline); err != nil {
+		log.Errorf("+++ failed to upload pipeline: %v", err)
+	}
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -54,9 +54,9 @@ func uploadPipeline(plugin Plugin, generatePipeline PipelineGenerator) (string, 
 		args = append(args, "--no-interpolation")
 	}
 
-	executeCommand("buildkite-agent", args)
+	_, err = executeCommand("buildkite-agent", args)
 
-	return cmd, args, nil
+	return cmd, args, err
 }
 
 func diff(command string) ([]string, error) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -39,7 +39,7 @@ func TestUploadPipelineCallsBuildkiteAgentCommand(t *testing.T) {
 
 	assert.Equal(t, "buildkite-agent", cmd)
 	assert.Equal(t, []string{"pipeline", "upload", "pipeline.txt"}, args)
-	assert.Equal(t, err, nil)
+	assert.Equal(t, err.Error(), "command `buildkite-agent` failed: exec: \"buildkite-agent\": executable file not found in $PATH")
 }
 
 func TestUploadPipelineCallsBuildkiteAgentCommandWithInterpolation(t *testing.T) {
@@ -48,7 +48,7 @@ func TestUploadPipelineCallsBuildkiteAgentCommandWithInterpolation(t *testing.T)
 
 	assert.Equal(t, "buildkite-agent", cmd)
 	assert.Equal(t, []string{"pipeline", "upload", "pipeline.txt", "--no-interpolation"}, args)
-	assert.Equal(t, err, nil)
+	assert.Equal(t, err.Error(), "command `buildkite-agent` failed: exec: \"buildkite-agent\": executable file not found in $PATH")
 }
 
 func TestUploadPipelineCancelsIfThereIsNoDiffOutput(t *testing.T) {


### PR DESCRIPTION
Without this feedback we're left simply with this vague output in
Buildkite.

> POST https://agent.buildkite.com/v3/jobs/<redacted\>/pipelines: 500 There was an unknown error uploading these steps. Please email us at support@buildkite.com and include this UUID `<redacted>` so we can investigate and get it fixed. (Attempt 1/60 Retrying in 5s)