### PR TITLE
feat: `skip_path` option in `watch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Declare a list of
     - assets/images/email
   config:
     trigger: email-deploy
+- path: services/webhooks
+  skip_path: services/webhooks/*.md
+  config:
+    trigger: webhooks-deploy
 ```
 
 ### `path`
@@ -163,6 +167,14 @@ If the `path` specified here in the appears in the `diff` output, a `trigger` st
 A list of paths can be provided to trigger the desired pipeline. Changes in any of the paths will initiate the pipeline provided in trigger.
 
 A `path` can also be a glob pattern. For example specify `path: "**/*.md"` to match all markdown files.
+
+### `skip_path`
+
+If the `skip_path` specified here in the appears in the `diff` output, the `trigger` step will not be added to the dynamically generated `pipeline.yaml`. However, if the `diff` output contains matches with `path` that don't match `skip_path`, the `trigger` step will still be added to the dynamically generated `pipeline.yaml`.
+
+A list of paths can be provided that should not trigger the desired pipeline. Changes in any of these paths will not initiate the pipeline provided in trigger.
+
+A `skip_path` can also be a glob pattern. For example specify `path: "**/*.md"` to not add the `trigger` step if only markdown files are modified.
 
 ### `config`
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -84,10 +84,25 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 		for _, p := range w.Paths {
 			for _, f := range files {
 				match, err := matchPath(p, f)
+
+				skip := false
+				for _, sp := range w.SkipPaths {
+					skipMatch, errSkip := matchPath(sp, f)
+
+					if errSkip != nil {
+						return nil, errSkip
+					}
+
+					if skipMatch {
+						skip = true
+					}
+				}
+
 				if err != nil {
 					return nil, err
 				}
-				if match {
+
+				if match && !skip {
 					steps = append(steps, w.Step)
 					break
 				}

--- a/plugin.go
+++ b/plugin.go
@@ -29,9 +29,11 @@ type HookConfig struct {
 
 // WatchConfig Plugin watch configuration
 type WatchConfig struct {
-	RawPath interface{} `json:"path"`
-	Paths   []string
-	Step    Step `json:"config"`
+	RawPath     interface{} `json:"path"`
+	Paths       []string
+	Step        Step        `json:"config"`
+	RawSkipPath interface{} `json:"skip_path"`
+	SkipPaths   []string
 }
 
 // Step is buildkite pipeline definition
@@ -100,8 +102,8 @@ func (plugin *Plugin) UnmarshalJSON(data []byte) error {
 	plugin.Env = parseEnv(plugin.RawEnv)
 	plugin.RawEnv = nil
 
-	// Path can be string or an array of strings,
-	// handle both cases and create an array of paths.
+	// Path and SkipPath can be string or an array of strings,
+	// handle both cases and create an array of paths on both.
 	for i, p := range plugin.Watch {
 		switch p.RawPath.(type) {
 		case string:
@@ -112,6 +114,15 @@ func (plugin *Plugin) UnmarshalJSON(data []byte) error {
 			}
 		}
 
+		switch p.RawSkipPath.(type) {
+		case string:
+			plugin.Watch[i].SkipPaths = []string{plugin.Watch[i].RawSkipPath.(string)}
+		case []interface{}:
+			for _, v := range plugin.Watch[i].RawSkipPath.([]interface{}) {
+				plugin.Watch[i].SkipPaths = append(plugin.Watch[i].SkipPaths, v.(string))
+			}
+		}
+
 		if plugin.Watch[i].Step.Trigger != "" {
 			setBuild(&plugin.Watch[i].Step.Build)
 		}
@@ -119,6 +130,7 @@ func (plugin *Plugin) UnmarshalJSON(data []byte) error {
 		appendEnv(&plugin.Watch[i], plugin.Env)
 
 		p.RawPath = nil
+		p.RawSkipPath = nil
 	}
 
 	return nil
@@ -165,6 +177,7 @@ func appendEnv(watch *WatchConfig, env map[string]string) {
 	watch.Step.RawEnv = nil
 	watch.Step.Build.RawEnv = nil
 	watch.RawPath = nil
+	watch.RawSkipPath = nil
 }
 
 // parse env in format from env=env-value to map[env] = env-value

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -143,6 +143,13 @@ EOM
           "config": {
             "trigger": "markdown-pipeline"
           }
+        },
+        {
+          "path": "**/*.md",
+          "skip_path": "**/*.secret.md",
+          "config": {
+            "trigger": "markdown-pipeline"
+          }
         }
       ]
     }


### PR DESCRIPTION
This PR adds support for specifying a `skip_path` option that support either a path or a list of paths that shouldn't result in adding the `trigger` step as part of the dynamically generated pipeline.

Note even in cases where a line in the `diff` is skipped due to `skip_path` and there are other paths in the `diff` that match `path` but doesn't match `skip_path`, the step will still be added to the dynamically generated pipeline. i.e. for the step to be effectively ignored, the paths in `skip_path` should match all of those in the given `diff`.

## Motivation

The motivation for this is the lack of support for negation cases in `doublestar` (the package used for glob pattern matching) See https://github.com/bmatcuk/doublestar/issues/49. 

I had a use case where I needed to avoid changes in certain subdirectories to trigger a step (if there were the only changes in the diff) and I tried to use the following pattern: `path: "/main/{*,!(subdir1|subdir2)/**/*}"` which should be a valid glob for filtering out `subdir1` and `subdir2`, but didn't work.

With this, I could instead do something like:

```yml
- path: "main/"
  skip_path:
    - "main/subdir1"
    - "main/subdir2"
```

and the result would be the same.