### PR TITLE
Add support for group steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,9 +7,9 @@ steps:
     plugins:
       - docker-compose#v3.3.0:
           run: plugin_test
-  - label: ":bomb: Triggering Plugin Version (2.0.3)"
+  - label: ":bomb: Triggers"
     plugins:
-      - chronotc/monorepo-diff#v2.0.3:
+      - chronotc/monorepo-diff:
           diff: "cat ./e2e/one-match-one-miss"
           watch:
             - path: "foo-service/"
@@ -21,9 +21,20 @@ steps:
           hooks:
             - command: echo "command hook 1"
             - command: echo "command hook 2"
-  - label: ":bomb: Triggering Plugin Version (2.0.4)"
+  - label: ":bomb: Testing groups"
     plugins:
-      - chronotc/monorepo-diff#v2.0.4:
+      - chronotc/monorepo-diff:
+          diff: "cat ./e2e/multiple-paths"
+          watch:
+            - path:
+                - "user-service/infrastructure/"
+                - "product-service/infrastructure/"
+              config:
+                group: "my group"
+                command: "echo i-am-running-in-a-group"
+  - label: ":bomb: Testing hooks"
+    plugins:
+      - chronotc/monorepo-diff:
           diff: "cat ./e2e/multiple-paths"
           watch:
             - path: "user-service/"
@@ -40,9 +51,9 @@ steps:
                 trigger: "this-pipeline-does-not-exists"
           hooks:
             - command: echo "command hook 1"
-  - label: ":bomb: Triggering Plugin Version (2.0.5)"
+  - label: ":bomb: Testing wait"
     plugins:
-      - chronotc/monorepo-diff#v2.0.5:
+      - chronotc/monorepo-diff:
           diff: "cat ./e2e/multiple-paths"
           watch:
             - path:
@@ -51,7 +62,7 @@ steps:
               config:
                 command: "echo i-am-running"
           wait: true
-  - label: ":bomb: Triggering Plugin Version (latest)"
+  - label: ":bomb: Testing triggers and commands"
     plugins:
       - chronotc/monorepo-diff:
           diff: "cat ./e2e/commands-or-triggers"
@@ -75,4 +86,9 @@ steps:
             - path:
                 - "do-not-run-command/"
               config:
+                command: "echo this-does-not-run"
+            - path:
+                - "global/"
+              config:
+                group: "this is a group"
                 command: "echo this-does-not-run"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0]
+
+### Added
+- Added support for [Group Steps](https://buildkite.com/docs/pipelines/group-step). [#89](https://github.com/chronotc/monorepo-diff-buildkite-plugin/pull/89) from [@xzyfer](https://github.com/xzyfer)
+
 ## [2.1.4]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ steps:
           watch:
             - path: app/cms/
               config:
+                group: ":rocket: deployment"
                 command: "netlify --production deploy"
                 label: ":netlify: Deploy to production"
                 agents:

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -245,6 +245,11 @@ func TestGeneratePipeline(t *testing.T) {
 			Trigger: "foo-service-pipeline",
 			Build:   Build{Message: "build message"},
 		},
+		{
+			Group:   "my group",
+			Trigger: "foo-service-pipeline",
+			Build:   Build{Message: "build message"},
+		},
 	}
 
 	want :=
@@ -252,6 +257,11 @@ func TestGeneratePipeline(t *testing.T) {
 - trigger: foo-service-pipeline
   build:
     message: build message
+- group: my group
+  steps:
+  - trigger: foo-service-pipeline
+    build:
+      message: build message
 - wait
 - command: echo "hello world"
 - command: cat ./file.txt`

--- a/plugin.go
+++ b/plugin.go
@@ -34,8 +34,14 @@ type WatchConfig struct {
 	Step    Step `json:"config"`
 }
 
+type Group struct {
+	Label string `yaml:"group"`
+	Steps []Step `yaml:"steps"`
+}
+
 // Step is buildkite pipeline definition
 type Step struct {
+	Group     string            `yaml:"group,omitempty"`
 	Trigger   string            `yaml:"trigger,omitempty"`
 	Label     string            `yaml:"label,omitempty"`
 	Build     Build             `yaml:"build,omitempty"`
@@ -59,6 +65,17 @@ type Build struct {
 	Commit  string            `yaml:"commit,omitempty"`
 	RawEnv  interface{}       `json:"env" yaml:",omitempty"`
 	Env     map[string]string `yaml:"env,omitempty"`
+}
+
+func (s Step) MarshalYAML() (interface{}, error) {
+	if s.Group == "" {
+		type Alias Step
+		return (Alias)(s), nil
+	}
+
+	label := s.Group
+	s.Group = ""
+	return Group{Label: label, Steps: []Step{s}}, nil
 }
 
 func initializePlugin(data string) (Plugin, error) {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -101,6 +101,16 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						},
 						"artifacts": [ "artifiact-1" ]
 					}
+				},
+				{
+					"path": "watch-path-1",
+					"config": {
+						"group": "my group",
+						"command": "echo hello-group",
+						"env": [
+							"env4", "hi= bye"
+						]
+					}
 				}
 			]
 		}
@@ -172,6 +182,20 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 					Async:     true,
 					Agents:    Agent{Queue: "queue-1"},
 					Artifacts: []string{"artifiact-1"},
+				},
+			},
+			{
+				Paths: []string{"watch-path-1"},
+				Step: Step{
+					Group:   "my group",
+					Command: "echo hello-group",
+					Env: map[string]string{
+						"env1": "env-1",
+						"env2": "env-2",
+						"env3": "env-3",
+						"env4": "env-4",
+						"hi":   "bye",
+					},
 				},
 			},
 		},

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -135,7 +135,8 @@ EOM
             "non-existant-service"
           ],
           "config": {
-            "command": "echo \"hello-world\""
+            "group": "my group",
+            "command": "echo \"hello group\""
           }
         },
         {
@@ -176,10 +177,11 @@ steps:
   - coverage/**/*
   - tests/*
   async: true
-- command: echo "hello-world"
+- group: my group
+  steps:
+  - command: echo "hello group"
 - wait
 - command: echo "hello world"
 - command: cat ./foo-file.txt
 EOM
 }
-


### PR DESCRIPTION
Fixes #82

Introduces an optional `group` field to the command `config`. If provided the command step is generated within a [Group Step](https://buildkite.com/docs/pipelines/group-step).