### PR TITLE
switch agent field to be a map instead of only queue

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -46,16 +46,11 @@ type Step struct {
 	Label     string            `yaml:"label,omitempty"`
 	Build     Build             `yaml:"build,omitempty"`
 	Command   string            `yaml:"command,omitempty"`
-	Agents    Agent             `yaml:"agents,omitempty"`
+	Agents    map[string]string `yaml:"agents,omitempty"`
 	Artifacts []string          `yaml:"artifacts,omitempty"`
 	RawEnv    interface{}       `json:"env" yaml:",omitempty"`
 	Env       map[string]string `yaml:"env,omitempty"`
 	Async     bool              `yaml:"async,omitempty"`
-}
-
-// Agent is Buildkite agent definition
-type Agent struct {
-	Queue string `yaml:"queue,omitempty"`
 }
 
 // Build is buildkite build definition

--- a/plugin.yml
+++ b/plugin.yml
@@ -43,9 +43,6 @@ configuration:
                   type: array
             agents:
               type: object
-              properties:
-                queue:
-                  type: string
             artifacts:
               type: array
             env:

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -97,7 +97,8 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						},
 						"async": true,
 						"agents": {
-							"queue": "queue-1"
+							"queue": "queue-1",
+							"custom_tag": "custom_value"
 						},
 						"artifacts": [ "artifiact-1" ]
 					}
@@ -180,7 +181,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						},
 					},
 					Async:     true,
-					Agents:    Agent{Queue: "queue-1"},
+					Agents:    map[string]string{"queue": "queue-1", "custom_tag": "custom_value"},
 					Artifacts: []string{"artifiact-1"},
 				},
 			},

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -115,7 +115,8 @@ EOM
             },
             "async": true,
             "agents": {
-              "queue": "foo-service-queue"
+              "queue": "foo-service-queue",
+              "custom_tag": "custom_value"
             },
             "artifacts": [
               "coverage/**/*",
@@ -173,6 +174,7 @@ steps:
     commit: commit-hash
   agents:
     queue: foo-service-queue
+    custom_tag: custom_value
   artifacts:
   - coverage/**/*
   - tests/*


### PR DESCRIPTION
Buildkite agent tags can be arbitrary key/value pairs, so let's switch that field to support that 🎉 

```
make test
go test -race -coverprofile=coverage.out -covermode=atomic
PASS
coverage: 86.7% of statements
ok  	github.com/chronotc/monorepo-diff-buildkite-plugin	0.258s
docker-compose run --rm plugin_test
Creating monorepo-diff-buildkite-plugin_plugin_test_run ... done
 ✓ Notify when the plugin cannot be parsed
 ✓ Pipeline is generated without wait property
 ✓ Pipeline is generated with build config from env
 ✓ Pipeline is generated with all options

4 tests, 0 failures
```

```
make quality
go vet
go fmt
go mod tidy
docker-compose run --rm plugin_lint
Creating monorepo-diff-buildkite-plugin_plugin_lint_run ... done
TAP version 13
ok 1 - plugin.yml is valid
ok 2 - All the readme config examples for plugin id 'chronotc/monorepo-diff' are valid (4 found)
ok 3 - Readme version numbers are up-to-date (v2.2.0)
1..3
# time=82.974ms
```