### PR TITLE
Don't unmarshal other plugin configs into Plugin struct until monorepo-diff's config has been identified

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -79,18 +79,23 @@ func (s Step) MarshalYAML() (interface{}, error) {
 }
 
 func initializePlugin(data string) (Plugin, error) {
-	var plugins []map[string]Plugin
+	var pluginConfigs []map[string]json.RawMessage
 
-	err := json.Unmarshal([]byte(data), &plugins)
-
-	if err != nil {
+	if err := json.Unmarshal([]byte(data), &pluginConfigs); err != nil {
 		log.Debug(err)
 		return Plugin{}, errors.New("failed to parse plugin configuration")
 	}
 
-	for _, p := range plugins {
-		for key, plugin := range p {
+	for _, p := range pluginConfigs {
+		for key, pluginConfig := range p {
 			if strings.HasPrefix(key, pluginName) {
+				var plugin Plugin
+
+				if err := json.Unmarshal(pluginConfig, &plugin); err != nil {
+					log.Debug(err)
+					return Plugin{}, errors.New("failed to parse plugin configuration")
+				}
+
 				return plugin, nil
 			}
 		}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -239,3 +239,29 @@ func TestPluginShouldOnlyFullyUnmarshallItselfAndNotOtherPlugins(t *testing.T) {
 	_, err := initializePlugin(param)
 	assert.NoError(t, err)
 }
+
+func TestPluginShouldErrorIfPluginConfigIsInvalid(t *testing.T) {
+	param := `[
+		{
+			"github.com/chronotc/monorepo-diff-buildkite-plugin#commit": {
+				"env": {
+					"anInvalidKey": "An Invalid Value"
+				},
+				"watch": [
+					{
+						"path": [
+							".buildkite/**/*"
+						],
+						"config": {
+							"label": "Example label",
+							"command": "echo hello world\\n"
+						}
+					}
+				]
+			}
+		}
+	]
+	`
+	_, err := initializePlugin(param)
+	assert.Error(t, err)
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -203,3 +203,39 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 
 	assert.Equal(t, expected, got)
 }
+
+func TestPluginShouldOnlyFullyUnmarshallItselfAndNotOtherPlugins(t *testing.T) {
+	param := `[
+		{
+			"github.com/example/example-plugin#commit": {
+				"env": {
+					"EXAMPLE_TOKEN": {
+						"json-key": ".TOKEN",
+						"secret-id": "global/example/token"
+					}
+				}
+			}
+		},
+		{
+			"github.com/chronotc/monorepo-diff-buildkite-plugin#commit": {
+				"watch": [
+					{
+						"env": [
+							"EXAMPLE_TOKEN"
+						],
+						"path": [
+							".buildkite/**/*"
+						],
+						"config": {
+							"label": "Example label",
+							"command": "echo hello world\\n"
+						}
+					}
+				]
+			}
+		}
+	]
+	`
+	_, err := initializePlugin(param)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
monorepo-diff would error out if another plugin with config keys that overlaps with its own, but has a different shape shows up in `BUILDKITE_PLUGINS`.

The solution is to do a shallow "unmarshal" enough to pick out monorepo-diff's configs, and then return the config as `Plugin` later.