### PR TITLE
Support `soft_fail` in the step config

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -158,11 +158,11 @@ func (plugin *Plugin) UnmarshalJSON(data []byte) error {
 
 func (s *Step) UnmarshalJSON(data []byte) error {
 	type plain Step
-	def := &plain{}
+	init := &plain{}
 
-	_ = json.Unmarshal(data, def)
+	_ = json.Unmarshal(data, init)
 
-	*s = Step(*def)
+	*s = Step(*init)
 
 	switch s.SoftFail.(type) {
 	case bool:

--- a/plugin.go
+++ b/plugin.go
@@ -39,6 +39,10 @@ type Group struct {
 	Steps []Step `yaml:"steps"`
 }
 
+type SoftFail struct {
+	ExitStatus interface{} `json:"exit_status" yaml:"exit_status"`
+}
+
 // Step is buildkite pipeline definition
 type Step struct {
 	Group     string            `yaml:"group,omitempty"`
@@ -51,6 +55,8 @@ type Step struct {
 	RawEnv    interface{}       `json:"env" yaml:",omitempty"`
 	Env       map[string]string `yaml:"env,omitempty"`
 	Async     bool              `yaml:"async,omitempty"`
+	SoftFail  SoftFail          `json:"soft_fail" yaml:"soft_fail,omitempty"`
+	// SoftFail interface{} `json:"soft_fail" yaml:"soft_fail,omitempty"`
 }
 
 // Agent is Buildkite agent definition
@@ -66,6 +72,9 @@ type Build struct {
 	RawEnv  interface{}       `json:"env" yaml:",omitempty"`
 	Env     map[string]string `yaml:"env,omitempty"`
 }
+
+// go type assertions
+// do assertion on s.SoftFail if it is boolean or SoftFail struct
 
 func (s Step) MarshalYAML() (interface{}, error) {
 	if s.Group == "" {

--- a/plugin.go
+++ b/plugin.go
@@ -39,10 +39,6 @@ type Group struct {
 	Steps []Step `yaml:"steps"`
 }
 
-type SoftFail struct {
-	ExitStatus interface{} `yaml:"exit_status"`
-}
-
 // Step is buildkite pipeline definition
 type Step struct {
 	Group     string            `yaml:"group,omitempty"`
@@ -153,27 +149,6 @@ func (plugin *Plugin) UnmarshalJSON(data []byte) error {
 		p.RawPath = nil
 	}
 
-	return nil
-}
-
-func (s *Step) UnmarshalJSON(data []byte) error {
-	type plain Step
-	init := &plain{}
-
-	_ = json.Unmarshal(data, init)
-
-	*s = Step(*init)
-
-	switch s.SoftFail.(type) {
-	case bool:
-		s.SoftFail = s.SoftFail.(bool)
-	case []interface{}:
-		var result []SoftFail
-		for _, v := range s.SoftFail.([]interface{}) {
-			result = append(result, SoftFail{ExitStatus: v.(map[string]interface{})["exit_status"]})
-		}
-		s.SoftFail = result
-	}
 	return nil
 }
 

--- a/plugin.go
+++ b/plugin.go
@@ -167,8 +167,12 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 	switch s.SoftFail.(type) {
 	case bool:
 		s.SoftFail = s.SoftFail.(bool)
-	case map[string]interface{}:
-		s.SoftFail = SoftFail{ExitStatus: s.SoftFail.(map[string]interface{})["exit_status"]}
+	case []interface{}:
+		var result []SoftFail
+		for _, v := range s.SoftFail.([]interface{}) {
+			result = append(result, SoftFail{ExitStatus: v.(map[string]interface{})["exit_status"]})
+		}
+		s.SoftFail = result
 	}
 	return nil
 }

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -167,7 +167,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env4": "env-4",
 						"hi":   "bye",
 					},
-					SoftFail: []SoftFail{{ExitStatus: "*"}},
+					SoftFail: []interface{}{map[string]interface{}{"exit_status": "*"}},
 				},
 			},
 			{
@@ -190,8 +190,8 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 					Async:     true,
 					Agents:    Agent{Queue: "queue-1"},
 					Artifacts: []string{"artifiact-1"},
-					SoftFail: []SoftFail{{
-						ExitStatus: float64(127),
+					SoftFail: []interface{}{map[string]interface{}{
+						"exit_status": float64(127),
 					}},
 				},
 			},

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -75,7 +75,10 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"command": "echo hello-world",
 						"env": [
 							"env4", "hi= bye"
-						]
+						],
+						"soft_fail": {
+							"exit_status": "*"
+						}
 					}
 				},
 				{
@@ -109,7 +112,10 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"command": "echo hello-group",
 						"env": [
 							"env4", "hi= bye"
-						]
+						],
+						"soft_fail": {
+							"exit_status": 1
+						}
 					}
 				}
 			]
@@ -160,6 +166,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env4": "env-4",
 						"hi":   "bye",
 					},
+					SoftFail: SoftFail{ExitStatus: "*"},
 				},
 			},
 			{
@@ -196,6 +203,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env4": "env-4",
 						"hi":   "bye",
 					},
+					SoftFail: SoftFail{ExitStatus: float64(1)},
 				},
 			},
 		},

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -76,9 +76,9 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env": [
 							"env4", "hi= bye"
 						],
-						"soft_fail": {
+						"soft_fail": [{
 							"exit_status": "*"
-						}
+						}]
 					}
 				},
 				{
@@ -103,9 +103,9 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 							"queue": "queue-1"
 						},
 						"artifacts": [ "artifiact-1" ],
-						"soft_fail": {
+						"soft_fail": [{
 							"exit_status": 127
-						}
+						}]
 					}
 				},
 				{
@@ -167,7 +167,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env4": "env-4",
 						"hi":   "bye",
 					},
-					SoftFail: SoftFail{ExitStatus: "*"},
+					SoftFail: []SoftFail{{ExitStatus: "*"}},
 				},
 			},
 			{
@@ -190,9 +190,9 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 					Async:     true,
 					Agents:    Agent{Queue: "queue-1"},
 					Artifacts: []string{"artifiact-1"},
-					SoftFail: SoftFail{
+					SoftFail: []SoftFail{{
 						ExitStatus: float64(127),
-					},
+					}},
 				},
 			},
 			{

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -102,7 +102,10 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"agents": {
 							"queue": "queue-1"
 						},
-						"artifacts": [ "artifiact-1" ]
+						"artifacts": [ "artifiact-1" ],
+						"soft_fail": {
+							"exit_status": 127
+						}
 					}
 				},
 				{
@@ -113,9 +116,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env": [
 							"env4", "hi= bye"
 						],
-						"soft_fail": {
-							"exit_status": 1
-						}
+						"soft_fail": true
 					}
 				}
 			]
@@ -189,6 +190,9 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 					Async:     true,
 					Agents:    Agent{Queue: "queue-1"},
 					Artifacts: []string{"artifiact-1"},
+					SoftFail: SoftFail{
+						ExitStatus: float64(127),
+					},
 				},
 			},
 			{
@@ -203,7 +207,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env4": "env-4",
 						"hi":   "bye",
 					},
-					SoftFail: SoftFail{ExitStatus: float64(1)},
+					SoftFail: true,
 				},
 			},
 		},

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -140,6 +140,26 @@ EOM
           }
         },
         {
+          "path": [
+            "bat-service/",
+            "non-existant-service"
+          ],
+          "config": {
+            "command": "echo \"i can fail\" && exit -1",
+            "soft_fail": true
+          }
+        },
+        {
+          "path": [
+            "bat-service/",
+            "non-existant-service"
+          ],
+          "config": {
+            "command": "echo \"i can fail\" && exit 1",
+            "soft_fail": [{ "exit_status": 1 }, { "exit_status": "255" }]
+          }
+        },
+        {
           "path": "**/*.md",
           "config": {
             "trigger": "markdown-pipeline"
@@ -180,6 +200,12 @@ steps:
 - group: my group
   steps:
   - command: echo "hello group"
+- command: echo "i can fail" && exit -1
+  soft_fail: true
+- command: echo "i can fail" && exit 1
+  soft_fail:
+  - exit_status: 1
+  - exit_status: "255"
 - wait
 - command: echo "hello world"
 - command: cat ./foo-file.txt


### PR DESCRIPTION
Add support for `soft_fail` command step config. Basically pass it along transparently.

Examples:

```
steps:
  - command: "tests.sh"
    soft_fail:
      - exit_status: 1

  - command: "tests.sh"
    soft_fail:
      - exit_status: "*"

  - command: "tests.sh"
    soft_fail: true
```


https://buildkite.com/docs/pipelines/command-step#soft-fail-attributes