### PR TITLE
Fatal on upload pipeline failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,6 @@ func main() {
 	setupLogger(plugin.LogLevel)
 
 	if _, _, err := uploadPipeline(plugin, generatePipeline); err != nil {
-		log.Errorf("+++ failed to upload pipeline: %v", err)
+		log.Fatalf("+++ failed to upload pipeline: %v", err)
 	}
 }


### PR DESCRIPTION
Currently, if the resulting Buildkite pipeline fails to upload for any reason (e.g. it attempts to trigger a second pipeline that doesn't exist yet), the build just exits successfully. There's some logging, but this is generally missed since the build doesn't fail.

This PR updates the error check on `uploadPipeline` to use `log.Fatalf`, which will fail the step if the pipeline can't be uploaded successfully. I can't think of a scenario where it's desirable for this to succeed when the pipeline upload failed.

Resolves #67 