### PR TITLE
Support both "commands" and "command" key, of any type

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -45,7 +45,8 @@ type Step struct {
 	Trigger   string            `yaml:"trigger,omitempty"`
 	Label     string            `yaml:"label,omitempty"`
 	Build     Build             `yaml:"build,omitempty"`
-	Command   string            `yaml:"command,omitempty"`
+	Command   interface{}       `yaml:"command,omitempty"`
+	Commands  interface{}       `yaml:"commands,omitempty"`
 	Agents    Agent             `yaml:"agents,omitempty"`
 	Artifacts []string          `yaml:"artifacts,omitempty"`
 	RawEnv    interface{}       `json:"env" yaml:",omitempty"`
@@ -172,7 +173,7 @@ func appendEnv(watch *WatchConfig, env map[string]string) {
 	watch.Step.Build.Env, _ = parseEnv(watch.Step.Build.RawEnv)
 
 	for key, value := range env {
-		if watch.Step.Command != "" {
+		if watch.Step.Command != nil || watch.Step.Commands != nil {
 			if watch.Step.Env == nil {
 				watch.Step.Env = make(map[string]string)
 			}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -164,6 +164,13 @@ EOM
           "config": {
             "trigger": "markdown-pipeline"
           }
+        },
+
+        {
+          "path": "bat-service/",
+          "config": {
+            "command": ["echo one", "echo two"]
+          }
         }
       ]
     }
@@ -206,6 +213,9 @@ steps:
   soft_fail:
   - exit_status: 1
   - exit_status: "255"
+- command:
+  - echo one
+  - echo two
 - wait
 - command: echo "hello world"
 - command: cat ./foo-file.txt


### PR DESCRIPTION
buildkite allows both of these keys, and allows them as lists of strings in addition to just strings

Fixes: #103