### PR TITLE
Rebuild plugin_test in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,24 @@ HAS_DOCKER=$(shell command -v docker;)
 .PHONY: all
 all: quality test
 
-.PHONY: test
-test:
+.PHONY: test-go
+test-go:
 	go test -race -coverprofile=coverage.out -covermode=atomic
+
+.PHONY: build-docker-test
+build-docker-test:
+ifneq (${HAS_DOCKER},)
+	docker-compose build plugin_test
+endif
+
+.PHONY: test-docker
+test-docker: build-docker-test
 ifneq (${HAS_DOCKER},)
 	docker-compose run --rm plugin_test
 endif
+
+.PHONY: test
+test: test-go test-docker
 
 .PHONY: quality
 quality:


### PR DESCRIPTION
Without this `make test` can run tests against a stale image, passing locally and failing in CI.