### PR TITLE
Ensure os type is always lowercase.

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -20,7 +20,7 @@ err() {
 }
 
 get_architecture() {
-  local _ostype="$(uname -s)"
+  local _ostype="$(uname -s | tr '[:upper:]' '[:lower:]')"
   local _arch="$(uname -m)"
   local _arm=("arm armhf aarch64 aarch64_be armv6l armv7l armv8l arm64e") # arm64
   local _amd=("x86 x86pc i386 i686 i686-64 x64 x86_64 x86_64h athlon")    # amd64


### PR DESCRIPTION
This fixes an issue where `uname -s` provides a result of capital `Linux` as seen here:

```
$ uname -s
Linux
```

We're running a Debian variant where this is true for our agent:

```
$ cat /etc/*release
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
NAME="Debian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

Without this change, we are unable to use the latest version of this plugin because of this error message in the command hook:

```
curl: (22) The requested URL returned error: 404
--
  | failed to download https://github.com/monebag/monorepo-diff-buildkite-plugin/releases/download/latest/monorepo-diff-buildkite-plugin_Linux_amd64
```

This is because the published binaries use lowercase "linux":

<img width="1511" alt="image" src="https://github.com/monebag/monorepo-diff-buildkite-plugin/assets/17505625/82cec885-6d5c-4c8d-ac83-2d14d06c1322">

I also find it a little wild that every invocation of this plugin is making a call to download a file from this repository and will open an issue to address that.