### PR TITLE
feat: add plugin support for downstream pipelines

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -22,6 +22,7 @@ type Plugin struct {
 	Env           map[string]string
 	RawNotify     []map[string]interface{} `json:"notify" yaml:",omitempty"`
 	Notify        []PluginNotify           `yaml:"notify,omitempty"`
+	Plugins       interface{}              `yaml:"plugins,omitempty"`
 }
 
 // HookConfig Plugin hook configuration
@@ -81,6 +82,7 @@ type Step struct {
 	SoftFail  interface{}              `json:"soft_fail" yaml:"soft_fail,omitempty"`
 	RawNotify []map[string]interface{} `json:"notify" yaml:",omitempty"`
 	Notify    []StepNotify             `yaml:"notify,omitempty"`
+	Plugins   interface{}              `yaml:"plugins,omitempty"`
 }
 
 // Agent is Buildkite agent definition


### PR DESCRIPTION
This PR adds the ability to provide the `plugins` keyword to individual downstream buildkite jobs. This is needed so that we can use other plugins for downstream jobs that monorepo-diff-buildkite-plugin is using. 

```
    plugins:
      - monebag/monorepo-diff#v2.5.8:
          ...
          watch:
            - path:
                - "foo/**"
              config:
                ...
                plugins:
                  - seek-oss/aws-sm#v2.3.1:
                      env:
                        AUTH_SECRET:
                          secret-id: "secret/id"
                          json-key: ".key"
            - path:
                - "bar/**"
              config:
                ...
                plugins:
                  - seek-oss/aws-sm#v2.3.1:
                      env:
                        AUTH_SECRET:
                          secret-id: "secret/id2"
                          json-key: ".key2"
```

See #142 for more information on the problem. 


- [ ] TODO: Add unit tests
- [ ] TODO: Update Readme examples

