### PR TITLE
Adds ability to use monorepo-diff-buildkite-plugin from the PATH

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -87,19 +87,24 @@ download_binary_and_run() {
   fi
 
   local test_mode="${BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_TEST_MODE:-false}"
+  local _command="./${_executable}"
 
   if [[ "$test_mode" == "false" ]]; then
-    downloader "$_url" "$_executable"
+    if check_cmd monorepo-diff-buildkite-plugin; then
+      _command="$(command -v monorepo-diff-buildkite-plugin)"
+    else
+      downloader "$_url" "$_executable"
 
-    if [ $? != 0 ]; then
-      say "failed to download $_url"
-      exit 1
+      if [ $? != 0 ]; then
+        say "failed to download $_url"
+        exit 1
+      fi
+
+      chmod +x ${_executable}
     fi
-
-    chmod +x ${_executable}
   fi
 
-  ./${_executable}
+  ${_command}
 }
 
 download_binary_and_run "$@" || exit 1

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -298,3 +298,25 @@ steps:
 - command: cat ./foo-file.txt
 EOM
 }
+
+@test "download skipped when command already present" {
+  # Disable "test" mode, which would have skipped the download anyway.
+  export BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_TEST_MODE="false"
+
+  # Stub uname -s to return a fake OS, that will fail to be downloaded if
+  # we try.
+  stub uname \
+    "-s : echo 'TESTOS'" \
+    "-m : echo 'x86'"
+
+  # Stub monorepo-diff-buildkite-plugin, so that command -v sees it.
+  stub monorepo-diff-buildkite-plugin \
+    ""
+
+  run $PWD/hooks/command
+
+  assert_success
+
+  unstub uname
+  unstub monorepo-diff-buildkite-plugin
+}


### PR DESCRIPTION
This PR is related to a few issues that have cropped up over time:

#68 
#140

As well as the unmerged PR:

#69 

The basic issue at hand is that the monorepo-diff-buildkite-plugin downloads a new copy of the binary every time it is run.

This is both a reliability issue (eventually, GitHub will 503 you for downloading the binary from releases so many times) as well as a security issue (if the binary was modified, there's no way to validate a checksum and ensure you always install the one you wanted).

This PR attempts a relatively simple fix, by checking if the plugin is already on the PATH when executing the command, and choosing the pre-existing copy if so.

Users who are concerned about re-downloading the binary can then modify their Buildkite Agent Workers to have a pre-cached binary that they have checksum'd and validated as they please.